### PR TITLE
Add data points to scan and survey results

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ a wifi introspection and scanning daemon for OpenWrt.
 the following ubus calls are provided:
 'wifi' @b95a57e0
 	"assoclist":{"ifname":"String"}
-	"scan":{"dump":"Boolean","ifname":"String"}
+	"scan":{"dump":"Boolean","ifname":"String","on_channel":"Boolean","ap_force":"Boolean"}
 	"cac":{"ifname":"String","channel":"Integer","width":"Integer"}
 	"reg":{"country":"String"}
 	"iface":{"phy":"Integer","sta":"Boolean","ap":"Boolean","mon":"Boolean","add":"String","delete":"String"}

--- a/README
+++ b/README
@@ -65,6 +65,13 @@ scan - trigger a site survey. once complete a notification will be broadcast.
 			"channel_utilization": true,
 			"admission_capacity": 0
 		},
+		"ht": "40+",
+		"ht_channels": [
+			6,
+			10
+		],
+		"wifi_modes": "11b/g/n",
+		"band": "2.4GHz",
 		"wpa_version": 2,
 		"auth_suites": "psk",
 		"quality": 33,

--- a/README
+++ b/README
@@ -102,3 +102,16 @@ the following events are generated
   - 'wifi.low.tx_rate': {"mac":"00:18:84:88:00:03","tx_rate":21700}
   - 'wifi.rps': {"mac":"00:18:84:88:00:03","tx_retries":46}
   - 'wifi.scan.done': {"ifname":"wlan0"}
+
+Automatic periodic scanning - to setup automatic periodic scanning set you need to specify:
+  - The PHY to bring up a scanning interface on or an interface that is already setup to use
+  - The time between scans in seconds.
+
+  Example Configuration:
+	u80211d.global.scan_phy=0 - Setup scanning interface on PHY 0
+	u80211d.global.scan_period=300 - Run a scan every 300 seconds (5 Minutes)
+
+  Example Configuration:
+	u80211d.global.scan_iface="wlan0" - Interface to scan on
+	u80211d.global.scan_period=300 - Run a scan every 300 seconds (5 Minutes)
+	u80211d.global.scan_ap_force=true - Run a scan even if the interface is an AP interface

--- a/config.c
+++ b/config.c
@@ -32,6 +32,7 @@ enum {
 	GLOBAL_ATTR_STATION_STATUS,
 	GLOBAL_ATTR_STATION_POLL,
 	GLOBAL_ATTR_SCAN_PHY,
+	GLOBAL_ATTR_SCAN_IFACE,
 	GLOBAL_ATTR_SCAN_PERIOD,
 	GLOBAL_ATTR_SCAN_DELAY,
 	GLOBAL_ATTR_SCAN_AP_FORCE,
@@ -48,6 +49,7 @@ static const struct blobmsg_policy global_attrs[__GLOBAL_ATTR_MAX] = {
 	[GLOBAL_ATTR_STATION_STATUS] = { .name = "station_status", .type = BLOBMSG_TYPE_INT32 },
 	[GLOBAL_ATTR_STATION_POLL] = { .name = "station_poll", .type = BLOBMSG_TYPE_INT32 },
 	[GLOBAL_ATTR_SCAN_PHY] = { .name = "scan_phy", .type = BLOBMSG_TYPE_INT32 },
+	[GLOBAL_ATTR_SCAN_IFACE] = { .name = "scan_iface", .type = BLOBMSG_TYPE_STRING },
 	[GLOBAL_ATTR_SCAN_PERIOD] = { .name = "scan_period", .type = BLOBMSG_TYPE_INT32 },
 	[GLOBAL_ATTR_SCAN_DELAY] = { .name = "scan_delay", .type = BLOBMSG_TYPE_INT32 },
 	[GLOBAL_ATTR_SCAN_AP_FORCE] = { .name = "scan_ap_force", .type = BLOBMSG_TYPE_BOOL },
@@ -90,6 +92,9 @@ static int config_load_global(struct uci_section *s)
 
 	if (tb[GLOBAL_ATTR_SCAN_PHY])
 		config.scan_phy = blobmsg_get_u32(tb[GLOBAL_ATTR_SCAN_PHY]);
+
+	if (tb[GLOBAL_ATTR_SCAN_IFACE])
+		snprintf(config.scan_iface, sizeof(config.scan_iface), "%s", blobmsg_get_string(tb[GLOBAL_ATTR_SCAN_IFACE]));
 
 	if (tb[GLOBAL_ATTR_SCAN_PERIOD])
 		config.scan_period = blobmsg_get_u32(tb[GLOBAL_ATTR_SCAN_PERIOD]);

--- a/config.c
+++ b/config.c
@@ -34,6 +34,7 @@ enum {
 	GLOBAL_ATTR_SCAN_PHY,
 	GLOBAL_ATTR_SCAN_PERIOD,
 	GLOBAL_ATTR_SCAN_DELAY,
+	GLOBAL_ATTR_SCAN_AP_FORCE,
 	GLOBAL_ATTR_COUNTRY,
 	__GLOBAL_ATTR_MAX,
 };
@@ -49,6 +50,7 @@ static const struct blobmsg_policy global_attrs[__GLOBAL_ATTR_MAX] = {
 	[GLOBAL_ATTR_SCAN_PHY] = { .name = "scan_phy", .type = BLOBMSG_TYPE_INT32 },
 	[GLOBAL_ATTR_SCAN_PERIOD] = { .name = "scan_period", .type = BLOBMSG_TYPE_INT32 },
 	[GLOBAL_ATTR_SCAN_DELAY] = { .name = "scan_delay", .type = BLOBMSG_TYPE_INT32 },
+	[GLOBAL_ATTR_SCAN_AP_FORCE] = { .name = "scan_ap_force", .type = BLOBMSG_TYPE_BOOL },
 	[GLOBAL_ATTR_COUNTRY] = { .name = "country", .type = BLOBMSG_TYPE_STRING },
 };
 
@@ -94,6 +96,9 @@ static int config_load_global(struct uci_section *s)
 
 	if (tb[GLOBAL_ATTR_SCAN_DELAY])
 		config.scan_delay = blobmsg_get_u32(tb[GLOBAL_ATTR_SCAN_DELAY]);
+
+	if (tb[GLOBAL_ATTR_SCAN_AP_FORCE])
+		config.scan_ap_force = blobmsg_get_u8(tb[GLOBAL_ATTR_SCAN_AP_FORCE]);
 
 	if (tb[GLOBAL_ATTR_COUNTRY])
 		config.country = blobmsg_get_string(tb[GLOBAL_ATTR_COUNTRY]);

--- a/nl80211.c
+++ b/nl80211.c
@@ -457,6 +457,8 @@ static void nl80211_handle_survey(struct nlattr **tb)
 	if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY])
 		blobmsg_add_u64(&s, "busy", nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY]));
 
+	blobmsg_add_u8(&s, "in_use", (sinfo[NL80211_SURVEY_INFO_IN_USE]) ? nla_get_u8(sinfo[NL80211_SURVEY_INFO_IN_USE]) : false);
+
 	blobmsg_close_table(&s, c);
 }
 

--- a/nl80211.c
+++ b/nl80211.c
@@ -457,6 +457,12 @@ static void nl80211_handle_survey(struct nlattr **tb)
 	if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY])
 		blobmsg_add_u64(&s, "busy", nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY]));
 
+	if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_TX])
+		blobmsg_add_u64(&s, "tx", nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_TX]));
+
+	if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_RX])
+		blobmsg_add_u64(&s, "rx", nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_RX]));
+
 	blobmsg_add_u8(&s, "in_use", (sinfo[NL80211_SURVEY_INFO_IN_USE]) ? nla_get_u8(sinfo[NL80211_SURVEY_INFO_IN_USE]) : false);
 
 	blobmsg_close_table(&s, c);

--- a/nl80211_scan.c
+++ b/nl80211_scan.c
@@ -244,6 +244,7 @@ static void iwinfo_parse_rsn(uint8_t *data, uint8_t len, char *defcipher, char *
 		if (!memcmp(data + 2 + (i * 4), ms_oui, 3) ||
 			!memcmp(data + 2 + (i * 4), ieee80211_oui, 3))
 		{
+			/* Table 9-133: AKM Suite Selectors - Suite Type */
 			switch (data[2 + (i * 4) + 3])
 			{
 				case 1:  /* IEEE 802.1x */
@@ -264,7 +265,7 @@ static void iwinfo_parse_rsn(uint8_t *data, uint8_t len, char *defcipher, char *
 					break;
 
 				case 8:  /* SAE */
-					blobmsg_add_u16(&s, "wpa_version", 4);
+					blobmsg_add_u16(&s, "wpa_version", 3);
 					blobmsg_add_string(&s, "auth_suites", "sae");
 					break;
 
@@ -274,7 +275,7 @@ static void iwinfo_parse_rsn(uint8_t *data, uint8_t len, char *defcipher, char *
 
 				case 11: /* 802.1x Suite-B */
 				case 12: /* 802.1x Suite-B-192 */
-					blobmsg_add_u16(&s, "wpa_version", 4);
+					blobmsg_add_u16(&s, "wpa_version", 3);
 					blobmsg_add_string(&s, "auth_suites", "8021x");
 					break;
 
@@ -286,7 +287,7 @@ static void iwinfo_parse_rsn(uint8_t *data, uint8_t len, char *defcipher, char *
 					break;
 
 				case 18: /* OWE */
-					blobmsg_add_u16(&s, "wpa_version", 4);
+					blobmsg_add_u16(&s, "wpa_version", 3);
 					blobmsg_add_string(&s, "auth_suites", "owe");
 					break;
 			}

--- a/u80211d.h
+++ b/u80211d.h
@@ -108,6 +108,7 @@ struct config {
 	uint32_t station_status;
 	uint32_t station_poll;
 	uint32_t scan_phy;
+	char scan_iface[IF_NAMESIZE];
 	uint32_t scan_period;
 	uint32_t scan_delay;
 	uint8_t scan_ap_force;

--- a/u80211d.h
+++ b/u80211d.h
@@ -110,6 +110,7 @@ struct config {
 	uint32_t scan_phy;
 	uint32_t scan_period;
 	uint32_t scan_delay;
+	uint8_t scan_ap_force;
 	char *country;
 };
 
@@ -176,7 +177,7 @@ extern int nl80211_init(void);
 extern void nl80211_deinit(void);
 extern int nl80211_init_scan(void);
 extern void nl80211_deinit_scan(void);
-extern int nl80211_trigger_scan(struct wifi_iface *wif, int on_channel);
+extern int nl80211_trigger_scan(struct wifi_iface *wif, int on_channel, int scan_flags);
 extern void nl80211_handle_new_scan_result(struct nlattr **tb, int iface);
 extern void nl80211_handle_trigger_scan(int iface, int start);
 extern int nl80211_reg_get(void);


### PR DESCRIPTION
This pull request brings in updates to how scan and survey results are collected and reported. Specifically adding more information to scan results such as channel types and widths, adding an option to pass the SCAN_FLAG_AP flag to the driver via netlink, and adding rx and tx times in the survey report.