### PR TITLE
Avoid use-after-free of wifi_iface after genl_send_and_recv

### DIFF
--- a/nl80211.c
+++ b/nl80211.c
@@ -112,21 +112,23 @@ static void nl80211_assoc_list(struct uloop_timeout *t)
 	int idx = if_nametoindex(wif->ifname);
 	struct nl_msg *msg;
 
+	/* schedule next poll before genl_send_and_recv - wif might be freed
+	 * afterwards
+	 */
+	uloop_timeout_set(t, config.station_poll * 1000);
+
 	msg = nlmsg_alloc();
 	if (!msg)
-		goto out;
+		return;
 
 	if (!genlmsg_put(msg, 0, 0, genl_ctrl_resolve(nl80211_status.sock, "nl80211"),
 			 0, NLM_F_DUMP, NL80211_CMD_GET_STATION, 0) ||
 		nla_put_u32(msg, NL80211_ATTR_IFINDEX, idx)) {
 		nlmsg_free(msg);
-		goto out;
+		return;
 	}
 
 	genl_send_and_recv(&nl80211_status, msg);
-
-out:
-	uloop_timeout_set(t, config.station_poll * 1000);
 }
 
 static void nl80211_parse_rateinfo(struct nlattr **ri, char *table)


### PR DESCRIPTION
It is not safe to access the wif->assoc after calling genl_send_and_recv because the memory of the wif might have been freed in the meantime. This would for example happen when:

* NL80211_CMD_NEW_INTERFACE is received over global netlink status socket
  - nl80211_add_iface creates wif + schedules timer via nl80211_assoc_list
* timout is triggered and nl80211_assoc_list is started
  - DUMP of NL80211_CMD_GET_STATION is started over global netlink status socket
  - genl_send_and_recv is first sending this message and then receiving all kind of messages from the nl80211 status socket
  - unfortunately, a NL80211_CMD_DEL_INTERFACE was just queued at that time in the netlink status socket by the kernel
    + daemon is parsing NL80211_CMD_DEL_INTERFACE and calls nl80211_del_iface
    + memory for the wif is removed (maybe even invalidated)
  - at some point genl_send_and_recv will finish
  - nl80211_assoc_list tries to schedule the next station poll via the wif->assoc (which is part of the wif memory which was just freed) -> CRASH or memory corruption

uloop_timeout_set on the wif->assoc must therefore be called before genl_send_and_recv is started.